### PR TITLE
Fix the error of val2017_foot training

### DIFF
--- a/training/a2_coco_jsonToMat.m
+++ b/training/a2_coco_jsonToMat.m
@@ -80,11 +80,11 @@ for mode = 0:1 % Body
     end
     % Foot_train
     if (mode == 3)
-        dataType = [dataType, '_foot_v1'];
+        dataType = [dataType, '_foot_v2'];
         numberKeyPoints = 23;
     % Foot_val
     elseif (mode == 2)
-        dataType = [dataType, '_foot_v1'];
+        dataType = [dataType, '_foot_v2'];
         numberKeyPoints = 6;
     % COCO
     elseif (mode == 0 || mode == 1)

--- a/training/a2_coco_jsonToMat.m
+++ b/training/a2_coco_jsonToMat.m
@@ -78,10 +78,14 @@ for mode = 0:1 % Body
     else
         assert(false, 'Unknown mode.');
     end
-    % Foot
-    if (mode == 2 || mode == 3)
-        dataType = [dataType, '_foot_v2'];
+    % Foot_train
+    if (mode == 3)
+        dataType = [dataType, '_foot_v1'];
         numberKeyPoints = 23;
+    % Foot_val
+    elseif (mode == 2)
+        dataType = [dataType, '_foot_v1'];
+        numberKeyPoints = 6;
     % COCO
     elseif (mode == 0 || mode == 1)
         numberKeyPoints = 17;

--- a/training/a4_coco_matToRefinedJson.m
+++ b/training/a4_coco_matToRefinedJson.m
@@ -49,6 +49,7 @@ for mode = modes
         load([sMatFolder, 'coco_kpt_foot.mat']);
         matAnnotations = coco_kpt;
         opt.FileName = [sJsonFolder, 'coco2017_foot.json'];
+%         sNumberKeyPoints = 6;
 %         dataType = 'val2017';
 %         load([sMatFolder, 'coco2017_val_foot.mat']);
 %         matAnnotations = coco_val;


### PR DESCRIPTION
1. When running foot validation dataset v1, the Matlab code crash because of wrong number of joints. (the json data has only 6 joints while the code says 23). The solution may be helpful to Issue #16 .

2. Foot dataset v2 not available yet, so change it to dataset v1, which may solve the Issue #12 , #22 . 

Thanks.